### PR TITLE
efficient links and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ In the next ***30 minutes*** you will learn _everything_<sup>1</sup> you need to
 If you're new to Testing Driven Development (**TDD**) read: http://en.wikipedia.org/wiki/Software_testing <br />
 
 And watch:
-- Video intro to Software Development Lifecycle: http://youtu.be/qMkV_TDdDeA
-- "What is Software Testing" video: http://youtu.be/UZy1Dj9JIg4
+- "What is Software Testing" video (from 5:56 onwards): https://youtu.be/UZy1Dj9JIg4?t=356
+- Video intro to Software Development Lifecycle (from 0:52 onwards): https://youtu.be/qMkV_TDdDeA?t=52
 - "**How to Write Clean, Testable Code**": http://youtu.be/XcT4yYu_TTs (ignore the Java code focus on the general principals )
 
 ## How?
@@ -440,7 +440,7 @@ Add the following test to `index.html` and refresh your browser:
 ```javascript
 test('getChange(486, 600) should equal [100, 10, 2, 2]', function(assert) {
   var result = getChange(486, 600);
-  var expected = [500, 10, 2, 2];
+  var expected = [100, 10, 2, 2];
   assert.deepEqual(result, expected);
 })
 ```
@@ -518,7 +518,7 @@ When these tests pass, your work is done.
 
 ```javascript
 function getChange(cost, paid){
-  var possibleCoins = [200, 100, 50, 25, 10, 5, 2, 1]; // Must be in decending order
+  var possibleCoins = [200, 100, 50, 20, 10, 5, 2, 1]; // Must be in decending order
   var changeToMake = paid - cost;
   var coinsToReturn = [];// Array we will fill with coins to return to the user
 
@@ -527,7 +527,7 @@ function getChange(cost, paid){
       if (changeToMake >= possibleCoins[i]) { // if changeToGive is larger than the current coin use that coin
         changeToMake -= possibleCoins[i]; // remove this coins value from the total change
         coinsToReturn.push(possibleCoins[i]); // add the coin to the return list of coins
-        i--; // Move back one to try the same coin again 
+        i--; // Move back one to try the same coin again
       }
     }
   }


### PR DESCRIPTION
I was thinking as the first 2 video links are by the same author and sequential that maybe it would make sense to list them in the order that that the author intended? (I'm following the guide we were given that explains when raising issues to ask them as a question, but reading this back is making me cringe because it sounds so patronising! Please don't take it that way :) To that end I switched them around.

I also considered that each of the first two video's content for learning, doesn't start at the beginning. Would it make sense to change the urls to the correct time-stamp (in one video the content begins at 6 mins in) and explain to watch from these times onwards in the link description? That might help students to understand that the videos are meant to be watched from that point without effecting the learning. I made these changes too. 

I think I spotted a couple of typos, I think that at line 443 [500, 10, 2, 2]; should read [100, 10, 2, 2]; as the difference above it adds up to 114 pence. At line 521 I believe that var possibleCoins = [200, 100, 50, 25, 10, 5, 2, 1];  should read var possibleCoins = [200, 100, 50, 20, 10, 5, 2, 1]; // Must be in decending order. As a later test expects the 20 coin not a 25 coin. I have made these changes.

However, possible reasons for including the typos could be as a learning tool for FAC students to spot errors and try and fix them and contribute via github and to teach students the peril of copy and pasting  solutions instead of following the instructions to create their own? The inclusion of British coins with explanation would suggest that it was intended for a wider audience so perhaps not. 

Many thanks and good vibes.

Josh