### PR TITLE
Updated : no need for ./node_modules references, and also fixed open …

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "istanbul cover test.js",
     "open-coverage": "open ./coverage/lcov-report/index.html",
-    "start": "node_modules/.bin/live-server --port=8000",
-    "docs": "./node_modules/jsdoc/jsdoc.js change.js",
-    "open-docs": "open ./out/global.html#getChange"
+    "start": "live-server --port=8000",
+    "docs": "jsdoc change.js",
+    "open-docs": "open ./out/global.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…docs not opening due to #

Since npm will try to find the modules from the bin in the local node_modules first. 
and they will be available there. 

also fixed open-docs not working. 
