### PR TITLE
Change global Istanbul use to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ node test.js
 
 And to see code server-side coverage:
 ```sh
-istanbul cover test.js
+./node_modules/.bin/istanbul cover test.js
 ```
 You should expect to see something like this in your terminal:
 


### PR DESCRIPTION
Running  `istanbul cover test.js` directly will not work as we only install it locally. This change should ensure the command works as expected.
Relates #79